### PR TITLE
Implement NNP/MM

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ python setup.py install
 Rscript -e 'install.packages("UWHAM", repos = "http://cran.us.r-project.org")' 
 ```
 
+For NNP, install `openmm-ml` and `nnpops`:
+```
+conda install -c conda-forge openmm-ml nnpops
+```
+
 `setproctitle` above is optional but useful to track the names of the processes started by AToM-OpenMM. The `ambertools` package is not an actual dependency but it is needed to set up some of the systems in the examples. `r-base`, and the `UWHAM R package` is required for free energy estimation. See [examples](examples/) for examples and tutorials.
 
 While we strive to develop and distribute high-quality and bug-free software, keep in mind that this is research software under heavy development. AToM is provided without any guarantees of correctness. Please report issues [here](https://github.com/Gallicchio-Lab/AToM-OpenMM/issues). We welcome contributions and pull requests.

--- a/ommsystem.py
+++ b/ommsystem.py
@@ -91,6 +91,16 @@ class OMMSystemAmber(OMMSystem):
         self.positions = self.inpcrd.positions
         self.boxvectors = self.inpcrd.boxVectors
 
+        if nnp_model := self.keywords.get('NNP_MODEL'):
+            from openmmml import MLPotential
+            self.logger.info(f'NNP model: {nnp_model}')
+            nnp = MLPotential(nnp_model)
+            nnp_atoms = list(map(int, self.keywords['LIGAND1_ATOMS'] + self.keywords['LIGAND2_ATOMS']))
+            self.logger.info(f'NNP atoms: {nnp_atoms}')
+            self.logger.info(f'Number of NNP atoms: {len(nnp_atoms)}')
+            assert len(nnp_atoms) > 0
+            self.system = nnp.createMixedSystem(self.topology, self.system, nnp_atoms, removeConstraints=False)
+
     def set_barostat(self,temperature,pressure,frequency):
         """
         sets the system Barostat; Currently applies the MonteCarlo Barostat

--- a/sync/worker.py
+++ b/sync/worker.py
@@ -52,7 +52,7 @@ class OMMWorkerATM:
             os.mkdir(wdir)
         self.logfile = open(os.path.join(wdir, basename), 'a+')
         nprnt = int(self.config.get('PRNT_FREQUENCY'))
-        self.simulation.reporters.append(StateDataReporter(self.logfile, nprnt, step=True, temperature=True))
+        self.simulation.reporters.append(StateDataReporter(self.logfile, nprnt, step=True, temperature=True, speed=True))
 
     def set_state(self, par):
         self.logger.debug("ommworker.set_state")


### PR DESCRIPTION
This enables to model the ligands with NNP and the rest system with MM.

Enable the feature:
```
NNP_MODEL = ani2x
```

Supported models: `ani1ccx` and `ani2x`